### PR TITLE
Feat/confirm allocations individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [0.6.1-beta] - 2019-09-30
+## [0.6.1-beta] - 2019-10-02
 ### Added
 - confirmations/contaminations are now only sent when the allocation is used
 - improved logging messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.6.1-beta] - 2019-09-30
+### Added
+- confirmations/contaminations are now only sent when the allocation is used
+- improved logging messages
+
 ## [0.6.0-beta] - 2019-05-31
 ### Fixed 
 - Participant's now initialize with the client instead of getting reused like before.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,7 @@ For a complete example of how to use this SDK see our [example app](https://gith
     ```java
        client.confirm();
     ```
-    *Note: After the client has initialized, it is important to confirm the participant into the experiment. This action
-     records the participant's allocation and sends the info back to Ascend.*
+    *Note: This action records the participant's allocation and sends the info back to Ascend.*
 
 ### Value Retrieval
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For a complete example of how to use this SDK see our [example app](https://gith
         <dependency>
           <groupId>ai.evolv</groupId>
           <artifactId>ascend-android-sdk</artifactId>
-          <version>0.6.0</version>
+          <version>0.6.1</version>
         </dependency>
     ```
 

--- a/ascend-sdk/build.gradle
+++ b/ascend-sdk/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'maven'
 
 group = "ai.evolv"
 archivesBaseName = "ascend-android-sdk"
-version = "0.6.0"
+version = "0.6.1"
 
 android {
     compileSdkVersion 28

--- a/ascend-sdk/src/main/java/ai/evolv/Allocations.java
+++ b/ascend-sdk/src/main/java/ai/evolv/Allocations.java
@@ -48,13 +48,15 @@ class Allocations {
                     JsonElement element = getElementFromGenome(allocation.get("genome"), keyParts);
                     T value = new Gson().fromJson(element, cls);
                     if (value != null) {
+                        LOGGER.debug(String.format("Found value for key '%s' in experiment %s",
+                                key, allocation.get("eid").getAsString()));
                         markTouched(allocation);
                         store.put(participant.getUserId(), allocations);
                     }
                     return value;
                 } catch (AscendKeyError e) {
-                    LOGGER.debug(String.format("Unable to find key %s in experiment %s.",
-                            keyParts.toString(), allocation.get("eid").getAsString()), e);
+                    LOGGER.debug(String.format("Unable to find key '%s' in experiment %s.",
+                            key, allocation.get("eid").getAsString()));
                     continue;
                 }
             }

--- a/ascend-sdk/src/main/java/ai/evolv/Allocations.java
+++ b/ascend-sdk/src/main/java/ai/evolv/Allocations.java
@@ -18,14 +18,20 @@ import org.slf4j.LoggerFactory;
 
 class Allocations {
 
+    private static final String TOUCHED = "touched";
+    private static final String CONFIRMED = "confirmed";
+    private static final String CONTAMINATED = "contaminated";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(Allocations.class);
 
     private final JsonArray allocations;
+    private final AscendAllocationStore store;
 
     private final Audience audience = new Audience();
 
-    Allocations(JsonArray allocations) {
+    Allocations(JsonArray allocations, AscendAllocationStore store) {
         this.allocations = allocations;
+        this.store = store;
     }
 
     <T> T getValueFromAllocations(String key, Class<T> cls, AscendParticipant participant)
@@ -40,7 +46,12 @@ class Allocations {
             if (!audience.filter(participant.getUserAttributes(), allocation)) {
                 try {
                     JsonElement element = getElementFromGenome(allocation.get("genome"), keyParts);
-                    return new Gson().fromJson(element, cls);
+                    T value = new Gson().fromJson(element, cls);
+                    if (value != null) {
+                        markTouched(allocation);
+                        store.put(participant.getUserId(), allocations);
+                    }
+                    return value;
                 } catch (AscendKeyError e) {
                     LOGGER.debug(String.format("Unable to find key %s in experiment %s.",
                             keyParts.toString(), allocation.get("eid").getAsString()), e);
@@ -123,4 +134,35 @@ class Allocations {
         }
         return activeExperiments;
     }
+
+    static JsonObject markTouched(JsonObject allocation) {
+        allocation.addProperty(TOUCHED, true);
+        return allocation;
+    }
+
+    static boolean isTouched(JsonObject allocation) {
+        return allocation.has(TOUCHED) &&
+                allocation.get(TOUCHED).getAsBoolean();
+    }
+
+    static JsonObject markConfirmed(JsonObject allocation) {
+        allocation.addProperty(CONFIRMED, true);
+        return allocation;
+    }
+
+    static boolean isConfirmed(JsonObject allocation) {
+        return allocation.has(CONFIRMED) &&
+                allocation.get(CONFIRMED).getAsBoolean();
+    }
+
+    static JsonObject markContaminated(JsonObject allocation) {
+        allocation.addProperty(CONTAMINATED, true);
+        return allocation;
+    }
+
+    static boolean isContaminated(JsonObject allocation) {
+        return allocation.has(CONTAMINATED) &&
+                allocation.get(CONTAMINATED).getAsBoolean();
+    }
+
 }

--- a/ascend-sdk/src/main/java/ai/evolv/Allocator.java
+++ b/ascend-sdk/src/main/java/ai/evolv/Allocator.java
@@ -92,16 +92,9 @@ class Allocator {
                     store.put(participant.getUserId(), allocations);
                     allocationStatus = AllocationStatus.RETRIEVED;
 
-                    if (confirmationSandbagged) {
-                        eventEmitter.confirm(allocations);
-                    }
-
-                    if (contaminationSandbagged) {
-                        eventEmitter.contaminate(allocations);
-                    }
-
                     allocationsFuture.set(allocations);
-                    executionQueue.executeAllWithValuesFromAllocations(allocations);
+                    executionQueue.executeAllWithValuesFromAllocations(allocations,
+                            eventEmitter, confirmationSandbagged, contaminationSandbagged);
                 } catch (Exception e) {
                     LOGGER.warn("There was a failure while retrieving the allocations.", e);
                     allocationsFuture.set(resolveAllocationFailure());
@@ -116,16 +109,10 @@ class Allocator {
         JsonArray previousAllocations = store.get(participant.getUserId());
         if (allocationsNotEmpty(previousAllocations)) {
             LOGGER.debug("Falling back to participant's previous allocation.");
-            if (confirmationSandbagged) {
-                eventEmitter.confirm(previousAllocations);
-            }
-
-            if (contaminationSandbagged) {
-                eventEmitter.contaminate(previousAllocations);
-            }
-
             allocationStatus = AllocationStatus.RETRIEVED;
-            executionQueue.executeAllWithValuesFromAllocations(previousAllocations);
+
+            executionQueue.executeAllWithValuesFromAllocations(previousAllocations, eventEmitter,
+                    confirmationSandbagged, contaminationSandbagged);
         } else {
             LOGGER.debug("Falling back to the supplied defaults.");
             allocationStatus = AllocationStatus.FAILED;

--- a/ascend-sdk/src/main/java/ai/evolv/Allocator.java
+++ b/ascend-sdk/src/main/java/ai/evolv/Allocator.java
@@ -40,7 +40,7 @@ class Allocator {
         this.participant = participant;
         this.httpClient = config.getHttpClient();
         this.allocationStatus = AllocationStatus.FETCHING;
-        this.eventEmitter = new EventEmitter(config, participant);
+        this.eventEmitter = new EventEmitter(config, participant, this.store);
 
     }
 

--- a/ascend-sdk/src/main/java/ai/evolv/AscendClientFactory.java
+++ b/ascend-sdk/src/main/java/ai/evolv/AscendClientFactory.java
@@ -44,7 +44,7 @@ public class AscendClientFactory {
         ListenableFuture<JsonArray> futureAllocations = allocator.fetchAllocations();
 
         return new AscendClientImpl(config,
-                new EventEmitter(config, participant),
+                new EventEmitter(config, participant, store),
                 futureAllocations,
                 allocator,
                 Allocator.allocationsNotEmpty(previousAllocations),

--- a/ascend-sdk/src/main/java/ai/evolv/AscendClientImpl.java
+++ b/ascend-sdk/src/main/java/ai/evolv/AscendClientImpl.java
@@ -49,7 +49,7 @@ class AscendClientImpl implements AscendClient {
             }
 
             GenericClass<T> cls = new GenericClass(defaultValue.getClass());
-            T value = new Allocations(allocations).getValueFromAllocations(key, cls.getMyType(),
+            T value = new Allocations(allocations, store).getValueFromAllocations(key, cls.getMyType(),
                     participant);
 
             if (value == null) {
@@ -70,7 +70,7 @@ class AscendClientImpl implements AscendClient {
 
     @Override
     public <T> void subscribe(String key, T defaultValue, AscendAction<T> function) {
-        Execution execution = new Execution<>(key, defaultValue, function, participant);
+        Execution execution = new Execution<>(key, defaultValue, function, participant, store);
         if (previousAllocations) {
             try {
                 JsonArray allocations = store.get(participant.getUserId());

--- a/ascend-sdk/src/main/java/ai/evolv/EventEmitter.java
+++ b/ascend-sdk/src/main/java/ai/evolv/EventEmitter.java
@@ -20,13 +20,15 @@ class EventEmitter {
     private final HttpClient httpClient;
     private final AscendConfig config;
     private final AscendParticipant participant;
+    private final AscendAllocationStore store;
 
     private final Audience audience = new Audience();
 
-    EventEmitter(AscendConfig config, AscendParticipant participant) {
+    EventEmitter(AscendConfig config, AscendParticipant participant, AscendAllocationStore store) {
         this.httpClient = config.getHttpClient();
         this.config = config;
         this.participant = participant;
+        this.store = store;
     }
 
     void emit(String key) {
@@ -49,17 +51,27 @@ class EventEmitter {
 
     void sendAllocationEvents(String key, JsonArray allocations) {
         for (JsonElement a : allocations) {
-            if (!audience.filter(participant.getUserAttributes(), a.getAsJsonObject())) {
-                JsonObject allocation = a.getAsJsonObject();
+            JsonObject allocation = a.getAsJsonObject();
+            if (!audience.filter(participant.getUserAttributes(), allocation) && Allocations.isTouched(allocation)
+                && !Allocations.isConfirmed(allocation) && !Allocations.isContaminated(allocation)) {
                 String experimentId = allocation.get("eid").getAsString();
                 String candidateId = allocation.get("cid").getAsString();
 
                 String url = getEventUrl(key, experimentId, candidateId);
                 makeEventRequest(url);
+
+                if (key.equals(CONFIRM_KEY)) {
+                    Allocations.markConfirmed(allocation);
+                } else if (key.equals(CONTAMINATE_KEY)) {
+                    Allocations.markContaminated(allocation);
+                }
+
                 continue;
             }
             LOGGER.debug(String.format("%s event filtered.", key));
         }
+
+        store.put(this.participant.getUserId(), allocations);
     }
 
     String getEventUrl(String type, Double score) {

--- a/ascend-sdk/src/main/java/ai/evolv/EventEmitter.java
+++ b/ascend-sdk/src/main/java/ai/evolv/EventEmitter.java
@@ -68,7 +68,8 @@ class EventEmitter {
 
                 continue;
             }
-            LOGGER.debug(String.format("%s event filtered.", key));
+            LOGGER.debug(String.format("%s event filtered for experiment %s.", key,
+                    allocation.get("eid").getAsString()));
         }
 
         store.put(this.participant.getUserId(), allocations);

--- a/ascend-sdk/src/main/java/ai/evolv/Execution.java
+++ b/ascend-sdk/src/main/java/ai/evolv/Execution.java
@@ -14,14 +14,17 @@ class Execution<T> {
     private final T defaultValue;
     private final AscendAction function;
     private final AscendParticipant participant;
+    private final AscendAllocationStore store;
 
     private Set<String> alreadyExecuted = new HashSet<>();
 
-    Execution(String key, T defaultValue, AscendAction<T> function, AscendParticipant participant) {
+    Execution(String key, T defaultValue, AscendAction<T> function, AscendParticipant participant,
+              AscendAllocationStore store) {
         this.key = key;
         this.defaultValue = defaultValue;
         this.function = function;
         this.participant = participant;
+        this.store = store;
     }
 
     String getKey() {
@@ -30,7 +33,7 @@ class Execution<T> {
 
     void executeWithAllocation(JsonArray rawAllocations) throws AscendKeyError {
         GenericClass<T> cls = new GenericClass(defaultValue.getClass());
-        Allocations allocations = new Allocations(rawAllocations);
+        Allocations allocations = new Allocations(rawAllocations, store);
         T value = allocations.getValueFromAllocations(key, cls.getMyType(), participant);
 
         if (value == null) {

--- a/ascend-sdk/src/main/java/ai/evolv/ExecutionQueue.java
+++ b/ascend-sdk/src/main/java/ai/evolv/ExecutionQueue.java
@@ -23,7 +23,9 @@ class ExecutionQueue {
         this.queue.add(execution);
     }
 
-    void executeAllWithValuesFromAllocations(JsonArray allocations) {
+    void executeAllWithValuesFromAllocations(JsonArray allocations, EventEmitter eventEmitter,
+                                             boolean confirmationSandbagged,
+                                             boolean contaminationSandbagged) {
         while (!queue.isEmpty()) {
             Execution execution = queue.remove();
             try {
@@ -36,6 +38,14 @@ class ExecutionQueue {
                 LOGGER.error("There was an issue while performing one of" +
                         " the stored actions.", e);
             }
+        }
+
+        if (confirmationSandbagged) {
+            eventEmitter.confirm(allocations);
+        }
+
+        if (contaminationSandbagged) {
+            eventEmitter.contaminate(allocations);
         }
     }
 

--- a/ascend-sdk/src/test/java/ai/evolv/AllocationsTest.java
+++ b/ascend-sdk/src/test/java/ai/evolv/AllocationsTest.java
@@ -24,12 +24,11 @@ public class AllocationsTest {
         return parser.parse(raw).getAsJsonArray();
     }
 
-
     @Test
     public void testGetValueFromAllocationGenome() {
         try {
             AscendParticipant participant = AscendParticipant.builder().build();
-            Allocations allocations = new Allocations(parseRawAllocations(rawAllocation));
+            Allocations allocations = new Allocations(parseRawAllocations(rawAllocation), new DefaultAllocationStore(10));
             Boolean featureImportance = allocations.getValueFromAllocations("algorithms.feature_importance",
                     Boolean.class, participant);
             Assert.assertEquals(featureImportance, false);
@@ -45,7 +44,7 @@ public class AllocationsTest {
     public void testGetValueFromMultiAllocationGenome() {
         try {
             AscendParticipant participant = AscendParticipant.builder().build();
-            Allocations allocations = new Allocations(parseRawAllocations(rawMultiAllocation));
+            Allocations allocations = new Allocations(parseRawAllocations(rawMultiAllocation), new DefaultAllocationStore(10));
             Boolean featureImportance = allocations.getValueFromAllocations("algorithms.feature_importance",
                     Boolean.class, participant);
             Assert.assertEquals(featureImportance, false);
@@ -61,7 +60,7 @@ public class AllocationsTest {
     public void testGetValueFromMultiAllocationWithDupsGenome() {
         try{
             AscendParticipant participant = AscendParticipant.builder().build();
-            Allocations allocations = new Allocations(parseRawAllocations(rawMultiAllocationWithDups));
+            Allocations allocations = new Allocations(parseRawAllocations(rawMultiAllocationWithDups), new DefaultAllocationStore(10));
             Boolean featureImportance = allocations.getValueFromAllocations("algorithms.feature_importance",
                     Boolean.class, participant);
             Assert.assertFalse(featureImportance);
@@ -75,7 +74,7 @@ public class AllocationsTest {
 
     @Test
     public void testGetActiveExperiments() {
-        Allocations allocations = new Allocations(parseRawAllocations(rawMultiAllocation));
+        Allocations allocations = new Allocations(parseRawAllocations(rawMultiAllocation), new DefaultAllocationStore(10));
         Set<String> activeExperiments = allocations.getActiveExperiments();
         Set<String> expected = new HashSet<>();
         expected.add("test_eid");

--- a/ascend-sdk/src/test/java/ai/evolv/AllocatorTest.java
+++ b/ascend-sdk/src/test/java/ai/evolv/AllocatorTest.java
@@ -146,7 +146,8 @@ public class AllocatorTest {
         Allocator allocator = new Allocator(mockConfig, participant);
         JsonArray actualAllocations = allocator.resolveAllocationFailure();
 
-        verify(mockExecutionQueue, times(1)).executeAllWithValuesFromAllocations(allocations);
+        verify(mockExecutionQueue, times(1)).executeAllWithValuesFromAllocations(eq(allocations),
+                any(), eq(false), eq(false));
         Assert.assertEquals(Allocator.AllocationStatus.RETRIEVED, allocator.getAllocationStatus());
         Assert.assertEquals(allocations, actualAllocations);
     }
@@ -164,10 +165,10 @@ public class AllocatorTest {
         allocator.sandBagConfirmation();
         JsonArray actualAllocations = allocator.resolveAllocationFailure();
 
-        verify(mockHttpClient, times(1))
-                .get(createConfirmationUrl(actualConfig, allocations.get(0).getAsJsonObject(), participant));
-        verify(mockExecutionQueue, times(1))
-                .executeAllWithValuesFromAllocations(allocations);
+        EventEmitter mockEventEmitter = new EventEmitter(mockConfig, participant, mockAllocationStore);
+
+        verify(mockExecutionQueue, times(1)).executeAllWithValuesFromAllocations(eq(allocations),
+                any(), eq(true), eq(false));
         Assert.assertEquals(Allocator.AllocationStatus.RETRIEVED, allocator.getAllocationStatus());
         Assert.assertEquals(allocations, actualAllocations);
     }
@@ -185,10 +186,8 @@ public class AllocatorTest {
         allocator.sandBagContamination();
         JsonArray actualAllocations = allocator.resolveAllocationFailure();
 
-        verify(mockHttpClient, times(1))
-                .get(createContaminationUrl(actualConfig, allocations.get(0).getAsJsonObject(), participant));
-        verify(mockExecutionQueue, times(1))
-                .executeAllWithValuesFromAllocations(allocations);
+        verify(mockExecutionQueue, times(1)).executeAllWithValuesFromAllocations(eq(allocations),
+                any(), eq(false), eq(true));
         Assert.assertEquals(Allocator.AllocationStatus.RETRIEVED, allocator.getAllocationStatus());
         Assert.assertEquals(allocations, actualAllocations);
     }
@@ -229,7 +228,8 @@ public class AllocatorTest {
         verify(mockAllocationStore, times(1)).get(participant.getUserId());
         verify(mockAllocationStore, times(1)).put(participant.getUserId(), allocations);
         Assert.assertEquals(Allocator.AllocationStatus.RETRIEVED, allocator.getAllocationStatus());
-        verify(mockExecutionQueue, times(1)).executeAllWithValuesFromAllocations(allocations);
+        verify(mockExecutionQueue, times(1)).executeAllWithValuesFromAllocations(eq(allocations),
+                any(), eq(false), eq(false));
     }
 
     @Test
@@ -250,7 +250,8 @@ public class AllocatorTest {
         verify(mockAllocationStore, times(1)).get(participant.getUserId());
         verify(mockAllocationStore, times(1)).put(participant.getUserId(), allocations);
         Assert.assertEquals(Allocator.AllocationStatus.RETRIEVED, allocator.getAllocationStatus());
-        verify(mockExecutionQueue, times(1)).executeAllWithValuesFromAllocations(allocations);
+        verify(mockExecutionQueue, times(1)).executeAllWithValuesFromAllocations(eq(allocations),
+                any(), eq(false), eq(false));
     }
 
 }

--- a/ascend-sdk/src/test/java/ai/evolv/EventEmitterTest.java
+++ b/ascend-sdk/src/test/java/ai/evolv/EventEmitterTest.java
@@ -19,7 +19,7 @@ public class EventEmitterTest {
     private static final double score = 10.0;
     private static final String eid = "test_eid";
     private static final String cid = "test_cid";
-    private static final String rawAllocation = "[{\"uid\":\"test_uid\",\"sid\":\"test_sid\",\"eid\":\"test_eid\",\"cid\":\"test_cid\",\"genome\":{\"search\":{\"weighting\":{\"distance\":2.5,\"dealer_score\":2.5}},\"pages\":{\"all_pages\":{\"header_footer\":[\"blue\",\"white\"]},\"testing_page\":{\"megatron\":\"none\",\"header\":\"white\"}},\"algorithms\":{\"feature_importance\":false}},\"excluded\":false}]";
+    private static final String rawAllocation = "[{\"uid\":\"test_uid\",\"sid\":\"test_sid\",\"eid\":\"test_eid\",\"cid\":\"test_cid\",\"touched\":true,\"genome\":{\"search\":{\"weighting\":{\"distance\":2.5,\"dealer_score\":2.5}},\"pages\":{\"all_pages\":{\"header_footer\":[\"blue\",\"white\"]},\"testing_page\":{\"megatron\":\"none\",\"header\":\"white\"}},\"algorithms\":{\"feature_importance\":false}},\"excluded\":false}]";
 
     @Mock
     private AscendConfig mockConfig;
@@ -91,7 +91,7 @@ public class EventEmitterTest {
                 mockExecutionQueue, mockHttpClient, mockAllocationStore);
 
         AscendParticipant participant = AscendParticipant.builder().build();
-        EventEmitter emitter = new EventEmitter(mockConfig, participant);
+        EventEmitter emitter = new EventEmitter(mockConfig, participant, mockAllocationStore);
         String url = emitter.getEventUrl(type, score);
         Assert.assertEquals(createEventsUrl(actualConfig, type, score, participant), url);
     }
@@ -104,7 +104,7 @@ public class EventEmitterTest {
         JsonArray allocations = new JsonParser().parse(rawAllocation).getAsJsonArray();
 
         AscendParticipant participant = AscendParticipant.builder().build();
-        EventEmitter emitter = new EventEmitter(mockConfig, participant);
+        EventEmitter emitter = new EventEmitter(mockConfig, participant, mockAllocationStore);
         String url = emitter.getEventUrl(type, eid, cid);
         Assert.assertEquals(createAllocationEventUrl(actualConfig, allocations.get(0).getAsJsonObject(), type, participant), url);
     }
@@ -117,7 +117,7 @@ public class EventEmitterTest {
         JsonArray allocations = new JsonParser().parse(rawAllocation).getAsJsonArray();
 
         AscendParticipant participant = AscendParticipant.builder().build();
-        EventEmitter emitter = new EventEmitter(mockConfig, participant);
+        EventEmitter emitter = new EventEmitter(mockConfig, participant, mockAllocationStore);
         emitter.sendAllocationEvents(type, allocations);
 
         verify(mockHttpClient, times(1))
@@ -132,7 +132,7 @@ public class EventEmitterTest {
         JsonArray allocations = new JsonParser().parse(rawAllocation).getAsJsonArray();
 
         AscendParticipant participant = AscendParticipant.builder().build();
-        EventEmitter emitter = new EventEmitter(mockConfig,participant);
+        EventEmitter emitter = new EventEmitter(mockConfig, participant, mockAllocationStore);
         emitter.contaminate(allocations);
 
         verify(mockHttpClient, times(1))
@@ -148,7 +148,7 @@ public class EventEmitterTest {
         JsonArray allocations = new JsonParser().parse(rawAllocation).getAsJsonArray();
 
         AscendParticipant participant = AscendParticipant.builder().build();
-        EventEmitter emitter = new EventEmitter(mockConfig, participant);
+        EventEmitter emitter = new EventEmitter(mockConfig, participant, mockAllocationStore);
         emitter.confirm(allocations);
 
         verify(mockHttpClient, times(1))
@@ -164,7 +164,7 @@ public class EventEmitterTest {
         JsonArray allocations = new JsonParser().parse(rawAllocation).getAsJsonArray();
 
         AscendParticipant participant = AscendParticipant.builder().build();
-        EventEmitter emitter = new EventEmitter(mockConfig, participant);
+        EventEmitter emitter = new EventEmitter(mockConfig, participant, mockAllocationStore);
         emitter.emit(type);
 
         verify(mockHttpClient, times(1))
@@ -179,7 +179,7 @@ public class EventEmitterTest {
         JsonArray allocations = new JsonParser().parse(rawAllocation).getAsJsonArray();
 
         AscendParticipant participant = AscendParticipant.builder().build();
-        EventEmitter emitter = new EventEmitter(mockConfig, participant);
+        EventEmitter emitter = new EventEmitter(mockConfig, participant, mockAllocationStore);
         emitter.emit(type, score);
 
         verify(mockHttpClient, times(1))


### PR DESCRIPTION
## [0.6.1-beta] - 2019-09-30
### Added
- confirmations/contaminations are now only sent when the allocation is used
- improved logging messages
